### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/donk0921/2bbcb02c-7149-4f48-8715-a57a1074240d/9a11c394-5642-46a0-be94-9577a3e3ab58/_apis/work/boardbadge/dda3d547-975a-4eba-8b01-4d17b6bacf87)](https://dev.azure.com/donk0921/2bbcb02c-7149-4f48-8715-a57a1074240d/_boards/board/t/9a11c394-5642-46a0-be94-9577a3e3ab58/Microsoft.RequirementCategory)
 # hello-world
 hello world practice


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/donk0921/2bbcb02c-7149-4f48-8715-a57a1074240d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.